### PR TITLE
Improve Codeforces URL parsing and support multiple contest types

### DIFF
--- a/manifest-chrome.partial.json
+++ b/manifest-chrome.partial.json
@@ -1,7 +1,13 @@
 {
     "manifest_version": 3,
-    "permissions": ["scripting", "webNavigation"],
-    "host_permissions": ["http://localhost/*", "https://codeforces.com/*"],
+    "permissions": [
+        "scripting",
+        "webNavigation"
+    ],
+    "host_permissions": [
+        "http://localhost/*",
+        "*://*.codeforces.com/*"
+    ],
     "background": {
         "service_worker": "dist/backgroundScript.js",
         "type": "module"

--- a/manifest-firefox.partial.json
+++ b/manifest-firefox.partial.json
@@ -6,7 +6,7 @@
     "permissions": [
         "scripting",
         "*://localhost/*",
-        "*://codeforces.com/*",
+        "*://*.codeforces.com/*",
         "webNavigation"
     ],
     "browser_specific_settings": {

--- a/src/handleSubmit.ts
+++ b/src/handleSubmit.ts
@@ -8,18 +8,77 @@ if (typeof browser !== 'undefined') {
     self.chrome = browser;
 }
 
-export const isContestProblem = (problemUrl: string) => {
-    return problemUrl.indexOf('contest') != -1;
+type SubmitRule = {
+    re: RegExp;
+    to: (match: RegExpMatchArray, origin: string) => string;
+    submitByIndex: boolean;
 };
 
-export const getSubmitUrl = (problemUrl: string) => {
-    if (!isContestProblem(problemUrl)) {
-        return config.cfSubmitPage.href;
+const SUBMIT_RULES: SubmitRule[] = [
+    {
+        re: /^\/contest\/(\d+)(?:\/problem\/(?<problemIndex>[^\/]+))?\/?$/,
+        to: (m, o) => `${o}/contest/${m[1]}/submit`,
+        submitByIndex: true,
+    },
+    {
+        re: /^\/gym\/(\d+)(?:\/problem\/(?<problemIndex>[^\/]+))?\/?$/,
+        to: (m, o) => `${o}/gym/${m[1]}/submit`,
+        submitByIndex: true,
+    },
+    {
+        re: /^\/problemset\/gymProblem\/(\d+)\/(?<problemIndex>[^\/]+)\/?$/,
+        to: (m, o) => `${o}/gym/${m[1]}/submit`,
+        submitByIndex: true,
+    },
+    {
+        re: /^\/group\/([^\/]+)\/contest\/(\d+)(?:\/problem\/(?<problemIndex>[^\/]+))?\/?$/,
+        to: (m, o) => `${o}/group/${m[1]}/contest/${m[2]}/submit`,
+        submitByIndex: true,
+    },
+    {
+        re: /^\/edu\/course\/([^\/]+)\/lesson\/([^\/]+)\/([^\/]+)\/practice\/contest\/(\d+)\/problem\/(?<problemIndex>[^\/]+)\/?$/,
+        to: (m, o) => `${o}/edu/course/${m[1]}/lesson/${m[2]}/${m[3]}/practice/contest/${m[4]}/submit`,
+        submitByIndex: true,
+    },
+    {
+        re: /^\/problemset\/problem\/(\d+)\/(?<problemIndex>[^\/]+)\/?$/,
+        to: (m, o) => `${o}/problemset/submit/${m[1]}/${m[2]}`,
+        submitByIndex: false,
+    },
+    {
+        re: /^\/problemsets\/acmsguru\/problem\/(\d+)\/(?<problemIndex>[^\/]+)\/?$/,
+        to: (m, o) => `${o}/problemsets/acmsguru/submit/${m[1]}/${m[2]}`,
+        submitByIndex: false,
+    },
+];
+
+const DEFAULT_SUBMIT_TARGET = {
+    submitUrl: config.cfSubmitPage.href,
+    submitByIndex: false,
+    problemIndex: null,
+};
+
+const resolveSubmitTarget = (problemUrl: string) => {
+    try {
+        const url = new URL(problemUrl);
+        const path = url.pathname;
+        const origin = `${url.protocol}//${url.host}`;
+
+        for (const rule of SUBMIT_RULES) {
+            const match = path.match(rule.re);
+            if (match) {
+                return {
+                    submitUrl: rule.to(match, origin),
+                    submitByIndex: rule.submitByIndex,
+                    problemIndex: match.groups?.problemIndex || null,
+                };
+            }
+        }
+
+        return DEFAULT_SUBMIT_TARGET;
+    } catch {
+        return DEFAULT_SUBMIT_TARGET;
     }
-    const url = new URL(problemUrl);
-    const contestNumber = url.pathname.split('/')[2];
-    const submitURL = `https://codeforces.com/contest/${contestNumber}/submit`;
-    return submitURL;
 };
 
 /** Opens the codefoces submit page and injects script to submit code. */
@@ -29,16 +88,20 @@ export const handleSubmit = async (
     sourceCode: string,
     problemUrl: string,
 ) => {
-    if (problemName === '' || languageId == -1 || sourceCode == '') {
+    // Ignore problemName from the data, as the VS Code extension's regex is currently outdated
+    if (languageId == -1 || sourceCode == '') {
         log('Invalid arguments to handleSubmit');
         return;
     }
 
-    log('isContestProblem', isContestProblem(problemUrl));
+    const submitTarget = resolveSubmitTarget(problemUrl);
+
+    log('isContestProblem', submitTarget.submitByIndex);
+    log('problemIndex', submitTarget.problemIndex);
 
     let tab = await chrome.tabs.create({
         active: true,
-        url: getSubmitUrl(problemUrl),
+        url: submitTarget.submitUrl,
     });
 
     const tabId = tab.id as number;
@@ -63,6 +126,8 @@ export const handleSubmit = async (
     chrome.tabs.sendMessage(tabId, {
         type: 'cph-submit',
         problemName,
+        problemIndex: submitTarget.problemIndex,
+        submitByIndex: submitTarget.submitByIndex,
         languageId,
         sourceCode,
         url: problemUrl,

--- a/src/injectedScript.ts
+++ b/src/injectedScript.ts
@@ -10,10 +10,6 @@ if (typeof browser !== 'undefined') {
 
 log('cph-submit script injected');
 
-const isContestProblem = (problemUrl: string) => {
-    return problemUrl.indexOf('contest') != -1;
-};
-
 const handleData = (data: ContentScriptData) => {
     log('Handling submit message');
     const languageEl = document.getElementsByName(
@@ -26,20 +22,14 @@ const handleData = (data: ContentScriptData) => {
     sourceCodeEl.value = data.sourceCode;
     languageEl.value = data.languageId.toString();
 
-    if (!isContestProblem(data.url)) {
-        const problemNameEl = document.getElementsByName(
-            'submittedProblemCode',
-        )[0] as HTMLInputElement;
-
-        problemNameEl.value = data.problemName;
-    } else {
+    if (data.submitByIndex) {
         const problemIndexEl = document.getElementsByName(
             'submittedProblemIndex',
         )[0] as HTMLSelectElement;
 
-        // Dont use problemName from data as it includes the contest number.
-        const problemName = data.url.split('/problem/')[1];
-        problemIndexEl.value = problemName;
+        if (data.problemIndex) {
+            problemIndexEl.value = data.problemIndex;
+        }
     }
 
     log('Submitting problem');

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,6 @@ export type CphSubmitResponse = {
 
 export type ContentScriptData = {
     type: 'cph-submit';
+    problemIndex: string | null;
+    submitByIndex: boolean;
 } & CphSubmitResponse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
         /* Basic Options */
         // "incremental": true,                   /* Enable incremental compilation */
-        "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "target": "es2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
         "module": "es2015" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
         "lib": ["ES2015", "DOM"],
         // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
- Implement regex-based `SUBMIT_RULES` to support Gym, Groups, Edu, and ACM-GURU problems.
- Refactor URL resolution into `resolveSubmitTarget` for more robust problem index extraction.
- Update manifest host permissions to include subdomains (*.codeforces.com).
- Upgrade TypeScript target to ES2018 to support regex named capture groups.
- Fix: Ignore unreliable problem names from extension data in favor of URL-extracted indices.