### PR TITLE
Added direct Submission for CodeChef  & Atcoder with CPH creating codeChefInjectedScript and atcoderInjectedScript

### DIFF
--- a/manifest-chrome.partial.json
+++ b/manifest-chrome.partial.json
@@ -5,6 +5,7 @@
         "http://localhost/*",
         "https://cses.fi/*",
         "https://codeforces.com/*",
+        "*://*.codechef.com/*",
         "https://maang.in/*"
     ],
     "background": {

--- a/manifest-chrome.partial.json
+++ b/manifest-chrome.partial.json
@@ -6,6 +6,7 @@
         "https://cses.fi/*",
         "https://codeforces.com/*",
         "*://*.codechef.com/*",
+        "*://*.atcoder.jp/*",
         "https://maang.in/*"
     ],
     "background": {

--- a/manifest-firefox.partial.json
+++ b/manifest-firefox.partial.json
@@ -8,6 +8,7 @@
         "*://localhost/*",
         "https://cses.fi/*",
         "*://codeforces.com/*",
+        "*://*.codechef.com/*",
         "*://maang.in/*",
         "webNavigation"
     ],

--- a/manifest-firefox.partial.json
+++ b/manifest-firefox.partial.json
@@ -9,6 +9,7 @@
         "https://cses.fi/*",
         "*://codeforces.com/*",
         "*://*.codechef.com/*",
+        "*://*.atcoder.jp/*",
         "*://maang.in/*",
         "webNavigation"
     ],

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,8 @@
 # ![ICON](icon-48.png) cph-submit
 
-Browser add-on that enables direct submission on Codeforces,CSES and Maang.in
-with[Competitive Programming Helper](https://github.com/agrawal-d/cph).
+Browser add-on that enables direct submission on Codeforces,CodeChef,CSES and
+Maang.in with
+[Competitive Programming Helper](https://github.com/agrawal-d/cph).
 
 Available for Firefox and Google Chrome.
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # ![ICON](icon-48.png) cph-submit
 
-Browser add-on that enables direct submission on Codeforces,CodeChef,CSES and
-Maang.in with
+Browser add-on that enables direct submission on Codeforces,CodeChef,AtCoder
+CSES and Maang.in with
 [Competitive Programming Helper](https://github.com/agrawal-d/cph).
 
 Available for Firefox and Google Chrome.

--- a/src/atcoderInjectedScript.ts
+++ b/src/atcoderInjectedScript.ts
@@ -66,6 +66,7 @@ chrome.runtime.onMessage.addListener((message) => {
             'Error: Could not find the AtCoder language select box on this page.',
         );
     }
+    new Promise((r) => setTimeout(r, 3000));
 
     const cloudFareVerificationChecker = setInterval(() => {
         const tokenInput = document.querySelector(

--- a/src/atcoderInjectedScript.ts
+++ b/src/atcoderInjectedScript.ts
@@ -67,25 +67,13 @@ chrome.runtime.onMessage.addListener((message) => {
         );
     }
 
-    if (sourceCode) {
-        const script = document.createElement('script');
-        const escapedCode = sourceCode
-            .replace(/\\/g, '\\\\')
-            .replace(/`/g, '\\`');
+    const cloudFareVerificationChecker = setInterval(() => {
+        const tokenInput = document.querySelector(
+            'input[name="cf-turnstile-response"]',
+        ) as HTMLInputElement | null;
 
-        script.textContent = `
-            if (typeof ace !== 'undefined') {
-                const editor = ace.edit("editor");
-                editor.setValue(\`${escapedCode}\`);
-                editor.clearSelection();
-            } else {
-                const textArea = document.querySelector('.plain-textarea');
-                if (textArea) textArea.value = \`${escapedCode}\`;
-            }
-        `;
-
-        document.documentElement.appendChild(script);
-        script.remove();
-        log('Successfully injected source code into the editor.');
-    }
+        if (tokenInput && tokenInput.value) {
+            document.getElementById('submit')?.click();
+        }
+    }, 250);
 });

--- a/src/atcoderInjectedScript.ts
+++ b/src/atcoderInjectedScript.ts
@@ -1,0 +1,91 @@
+import { ContentScriptData } from './types';
+import log from './log';
+
+declare const ace: any;
+
+log('cph-submit atcoder script injected');
+
+const idToAtcoderLanguage: Record<number, string> = {
+    91: 'C++23 (GCC 15.2.0)',
+    89: 'C++ IOI-Style(GNU++20) (GCC 14.2.0)',
+    52: 'C++23 (Clang 21.1.0)',
+    43: 'C23 (GCC 14.2.0)',
+    79: 'C# 13.0 (.NET 9.0.8)',
+    28: 'D (DMD 2.111.0)',
+    87: 'Java24 (OpenJDK 24.0.2)',
+    88: 'Kotlin (Kotlin/JVM 2.2.10)',
+    19: 'OCaml (ocamlopt 5.3.0)',
+    4: 'Pascal (fpc 3.2.2)',
+    13: 'Perl (perl 5.38.2)',
+    6: 'PHP (PHP 8.4.12)',
+    55: 'JavaScript (Node.js 22.19.0)',
+    31: 'Python (CPython 3.13.7)',
+    70: 'Python (PyPy 3.11-v7.3.20)',
+    67: 'Ruby 3.4 (ruby 3.4.5)',
+    32: 'Go (go 1.25.1)',
+    98: 'Rust (rustc 1.89.0)',
+    20: 'Scala (Dotty 3.7.2)',
+    12: 'Haskell (GHC 9.8.4)',
+};
+
+chrome.runtime.onMessage.addListener((message) => {
+    if (message.type !== 'cph-submit-Atcoder') return;
+
+    const { sourceCode, languageId } = message;
+    const languageText = idToAtcoderLanguage[languageId];
+
+    if (!languageText) {
+        alert('The following language is not supported');
+        return;
+    }
+
+    const selectBox = document.querySelector(
+        'select[name="data.LanguageId"]',
+    ) as HTMLSelectElement;
+
+    if (selectBox) {
+        const options = Array.from(selectBox.options);
+        const targetOption = options.find(
+            (opt) => opt.text.trim() === languageText,
+        );
+
+        if (targetOption) {
+            const atcoderValue = targetOption.value;
+            selectBox.value = atcoderValue;
+            selectBox.dispatchEvent(new Event('change', { bubbles: true }));
+            log(
+                `Successfully set language to ${languageText} (Value: ${atcoderValue})`,
+            );
+        } else {
+            log(
+                `Error: Could not find an option matching the text "${languageText}" in the dropdown.`,
+            );
+        }
+    } else {
+        log(
+            'Error: Could not find the AtCoder language select box on this page.',
+        );
+    }
+
+    if (sourceCode) {
+        const script = document.createElement('script');
+        const escapedCode = sourceCode
+            .replace(/\\/g, '\\\\')
+            .replace(/`/g, '\\`');
+
+        script.textContent = `
+            if (typeof ace !== 'undefined') {
+                const editor = ace.edit("editor");
+                editor.setValue(\`${escapedCode}\`);
+                editor.clearSelection();
+            } else {
+                const textArea = document.querySelector('.plain-textarea');
+                if (textArea) textArea.value = \`${escapedCode}\`;
+            }
+        `;
+
+        document.documentElement.appendChild(script);
+        script.remove();
+        log('Successfully injected source code into the editor.');
+    }
+});

--- a/src/atcoderInjectedScript.ts
+++ b/src/atcoderInjectedScript.ts
@@ -28,7 +28,7 @@ const idToAtcoderLanguage: Record<number, string> = {
     12: 'Haskell (GHC 9.8.4)',
 };
 
-chrome.runtime.onMessage.addListener((message) => {
+chrome.runtime.onMessage.addListener(async (message) => {
     if (message.type !== 'cph-submit-Atcoder') return;
 
     const { sourceCode, languageId } = message;
@@ -66,14 +66,20 @@ chrome.runtime.onMessage.addListener((message) => {
             'Error: Could not find the AtCoder language select box on this page.',
         );
     }
-    new Promise((r) => setTimeout(r, 3000));
+    await new Promise((r) => setTimeout(r, 1500));
+    /* there is no cloudfare verification during live contests*/
+    const tokenInput = document.querySelector(
+        'input[name="cf-turnstile-response"]',
+    ) as HTMLInputElement | null;
+
+    if (!tokenInput) {
+        document.getElementById('submit')?.click();
+        return;
+    }
 
     const cloudFareVerificationChecker = setInterval(() => {
-        const tokenInput = document.querySelector(
-            'input[name="cf-turnstile-response"]',
-        ) as HTMLInputElement | null;
-
         if (tokenInput && tokenInput.value) {
+            clearInterval(cloudFareVerificationChecker);
             document.getElementById('submit')?.click();
         }
     }, 250);

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -1,6 +1,8 @@
 import { ContentScriptData } from './types';
 import log from './log';
 
+declare const ace: any;
+
 log(`cph-submit Codechef script injected`);
 
 const idToCodechefLanguage: Record<number, string> = {
@@ -47,19 +49,78 @@ const languageMap: Record<string, string> = {
     Rust: 'rust',
 };
 
-chrome.runtime.onMessage.addListener((message) => {
-    if (message.type !== 'cph-submit-codechef') return;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    const languageName = idToCodechefLanguage[message.languageId];
-    if (!languageName) return;
+const simulateHumanClick = (element: HTMLElement) => {
+    ['mouseover', 'mousedown', 'mouseup', 'click'].forEach((eventType) => {
+        element.dispatchEvent(
+            new MouseEvent(eventType, {
+                bubbles: true,
+                cancelable: true,
+                view: window,
+                buttons: 1,
+            }),
+        );
+    });
+};
 
-    const languageSelect = document.querySelector(
-        '#language-select',
-    ) as HTMLElement | null;
-    if (languageSelect) languageSelect.textContent = languageName;
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.type !== 'cph-submit-codechef') return false;
 
-    const languageInput = document.querySelector(
-        'input.MuiSelect-nativeInput',
-    ) as HTMLInputElement | null;
-    if (languageInput) languageInput.value = languageMap[languageName];
+    const execute = async () => {
+        try {
+            const languageName = idToCodechefLanguage[message.languageId];
+            if (!languageName) {
+                sendResponse({ success: false, error: 'Unsupported language' });
+                return;
+            }
+
+            const languageSelectBtn = document.querySelector(
+                '#language-select',
+            ) as HTMLElement | null;
+            if (languageSelectBtn) {
+                simulateHumanClick(languageSelectBtn);
+                await sleep(300);
+
+                const options = Array.from(
+                    document.querySelectorAll('[role="option"]'),
+                ) as HTMLElement[];
+                const targetOption = options.find((opt) => {
+                    const val = opt.getAttribute('data-value');
+                    return (
+                        val === languageMap[languageName] ||
+                        opt.textContent?.trim() === languageName
+                    );
+                });
+
+                if (targetOption) {
+                    simulateHumanClick(targetOption);
+                    await sleep(400);
+                }
+            }
+
+            const editor = document.querySelector('.ace_editor');
+            if (editor && typeof ace !== 'undefined') {
+                ace.edit(editor).setValue(message.sourceCode, -1);
+            }
+
+            await sleep(200);
+
+            const submitBtn = document.getElementById('submit_btn');
+            if (submitBtn) {
+                simulateHumanClick(submitBtn);
+                sendResponse({ success: true });
+            } else {
+                sendResponse({
+                    success: false,
+                    error: 'Submit button not found',
+                });
+            }
+        } catch (error: any) {
+            sendResponse({ success: false, error: error.message });
+        }
+    };
+
+    execute();
+    return true;
 });

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -1,0 +1,65 @@
+import { ContentScriptData } from './types';
+import log from './log';
+
+log(`cph-submit Codechef script injected`);
+
+const idToCodechefLanguage: Record<number, string> = {
+    42: 'C++',
+    50: 'C++',
+    54: 'C++',
+    61: 'C++',
+    89: 'C++',
+    91: 'C++',
+    52: 'C++',
+    43: 'C',
+    36: 'Java',
+    60: 'Java',
+    87: 'Java',
+    31: 'Python3',
+    7: 'Python3',
+    40: 'PyPy 3',
+    41: 'PyPy 3',
+    70: 'PyPy 3',
+    9: 'C#',
+    65: 'C#',
+    79: 'C#',
+    34: 'JavaScript',
+    55: 'JavaScript',
+    32: 'Go',
+    6: 'PHP',
+    83: 'Kotlin',
+    88: 'Kotlin',
+    75: 'Rust',
+    98: 'Rust',
+};
+
+const languageMap: Record<string, string> = {
+    'C++': 'C++',
+    Python3: 'PYTH 3',
+    C: 'C',
+    Java: 'JAVA',
+    'PyPy 3': 'PYPY3',
+    'C#': 'C#',
+    JavaScript: 'NODEJS',
+    Go: 'GO',
+    PHP: 'PHP',
+    Kotlin: 'KTLN',
+    Rust: 'rust',
+};
+
+chrome.runtime.onMessage.addListener((message) => {
+    if (message.type !== 'cph-submit-codechef') return;
+
+    const languageName = idToCodechefLanguage[message.languageId];
+    if (!languageName) return;
+
+    const languageSelect = document.querySelector(
+        '#language-select',
+    ) as HTMLElement | null;
+    if (languageSelect) languageSelect.textContent = languageName;
+
+    const languageInput = document.querySelector(
+        'input.MuiSelect-nativeInput',
+    ) as HTMLInputElement | null;
+    if (languageInput) languageInput.value = languageMap[languageName];
+});

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -64,14 +64,14 @@ const simulateHumanClick = (element: HTMLElement) => {
     });
 };
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message) => {
     if (message.type !== 'cph-submit-codechef') return false;
 
     const execute = async () => {
         try {
             const languageName = idToCodechefLanguage[message.languageId];
             if (!languageName) {
-                sendResponse({ success: false, error: 'Unsupported language' });
+                alert('Language is not supported');
                 return;
             }
 
@@ -109,15 +109,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             const submitBtn = document.getElementById('submit_btn');
             if (submitBtn) {
                 simulateHumanClick(submitBtn);
-                sendResponse({ success: true });
+                log('button submitted succesfully');
             } else {
-                sendResponse({
-                    success: false,
-                    error: 'Submit button not found',
-                });
+                alert('submit button not found please submit manually');
             }
-        } catch (error: any) {
-            sendResponse({ success: false, error: error.message });
+        } catch (error) {
+            log(error);
         }
     };
 

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -71,7 +71,7 @@ chrome.runtime.onMessage.addListener((message) => {
         try {
             const languageName = idToCodechefLanguage[message.languageId];
             if (!languageName) {
-                alert('Language is not supported');
+                alert('Current Language is not supported');
                 return;
             }
 
@@ -109,7 +109,7 @@ chrome.runtime.onMessage.addListener((message) => {
             const submitBtn = document.getElementById('submit_btn');
             if (submitBtn) {
                 simulateHumanClick(submitBtn);
-                log('button submitted succesfully');
+                log('problem submitted succesfully');
             } else {
                 alert('submit button not found please submit manually');
             }
@@ -119,5 +119,5 @@ chrome.runtime.onMessage.addListener((message) => {
     };
 
     execute();
-    return true;
+    
 });

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -119,5 +119,4 @@ chrome.runtime.onMessage.addListener((message) => {
     };
 
     execute();
-    
 });

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -101,6 +101,8 @@ chrome.runtime.onMessage.addListener((message) => {
         } catch (error) {
             log(error);
         }
+        await new Promise((r) => setTimeout(r, 1500));
+        document.getElementById('submit_btn')?.click();
     };
 
     execute();

--- a/src/codeChefInjectedScript.ts
+++ b/src/codeChefInjectedScript.ts
@@ -98,21 +98,6 @@ chrome.runtime.onMessage.addListener((message) => {
                     await sleep(400);
                 }
             }
-
-            const editor = document.querySelector('.ace_editor');
-            if (editor && typeof ace !== 'undefined') {
-                ace.edit(editor).setValue(message.sourceCode, -1);
-            }
-
-            await sleep(200);
-
-            const submitBtn = document.getElementById('submit_btn');
-            if (submitBtn) {
-                simulateHumanClick(submitBtn);
-                log('problem submitted succesfully');
-            } else {
-                alert('submit button not found please submit manually');
-            }
         } catch (error) {
             log(error);
         }

--- a/src/handleSubmit.ts
+++ b/src/handleSubmit.ts
@@ -2,6 +2,7 @@ import config from './config';
 import log from './log';
 
 declare const browser: any;
+declare const ace: any; //This is required for platfroms using ace code Editor
 
 if (typeof browser !== 'undefined') {
     self.chrome = browser;
@@ -96,6 +97,14 @@ export const isCSESProblem = (problemUrl: string) => {
     try {
         const url = new URL(problemUrl);
         return url.hostname === 'cses.fi' || url.hostname.endsWith('.cses.fi');
+    } catch {
+        return false;
+    }
+};
+export const isCodeChefProblem = (problemUrl: string) => {
+    try {
+        const url = new URL(problemUrl);
+        return url.hostname.endsWith('codechef.com');
     } catch {
         return false;
     }
@@ -202,6 +211,66 @@ export const handleCSESSubmit = async (
         },
     );
 };
+export const handleCodeChefSubmit = async (
+    problemName: string,
+    languageId: number,
+    sourceCode: string,
+    problemUrl: string,
+) => {
+    const tab = await chrome.tabs.create({ active: true, url: problemUrl });
+    const tabId = tab.id as number;
+    chrome.windows.update(tab.windowId, { focused: true });
+
+    chrome.tabs.onUpdated.addListener(
+        function listener(updatedTabId, changeInfo) {
+            if (updatedTabId === tabId && changeInfo.status === 'complete') {
+                chrome.tabs.onUpdated.removeListener(listener);
+
+                setTimeout(async () => {
+                    await chrome.scripting.executeScript({
+                        target: { tabId, allFrames: false },
+                        files: ['/dist/codeChefInjectedScript.js'],
+                    });
+
+                    chrome.tabs.sendMessage(tabId, {
+                        type: 'cph-submit-codechef',
+                        languageId,
+                    });
+
+                    /**ChromeV3 don't Allow us to inject script due to CSP policy**/
+                    setTimeout(async () => {
+                        await chrome.scripting.executeScript({
+                            target: { tabId, allFrames: false },
+                            world: 'MAIN',
+                            func: (code) => {
+                                const w = window as any;
+                                if (w.ace)
+                                    w.ace
+                                        .edit(
+                                            document.querySelector(
+                                                '.ace_editor',
+                                            ),
+                                        )
+                                        .setValue(code, -1);
+                            },
+                            args: [sourceCode],
+                        });
+
+                        setTimeout(() => {
+                            chrome.scripting.executeScript({
+                                target: { tabId, allFrames: false },
+                                func: () =>
+                                    document
+                                        .getElementById('submit_btn')
+                                        ?.click(),
+                            });
+                        }, 500);
+                    }, 1000);
+                }, 2000);
+            }
+        },
+    );
+};
 export const handleSubmit = async (
     problemName: string,
     languageId: number,
@@ -223,6 +292,14 @@ export const handleSubmit = async (
     }
     if (isCSESProblem(problemUrl)) {
         return handleCSESSubmit(
+            problemName,
+            languageId,
+            sourceCode,
+            problemUrl,
+        );
+    }
+    if (isCodeChefProblem(problemUrl)) {
+        return handleCodeChefSubmit(
             problemName,
             languageId,
             sourceCode,

--- a/src/handleSubmit.ts
+++ b/src/handleSubmit.ts
@@ -2,7 +2,7 @@ import config from './config';
 import log from './log';
 
 declare const browser: any;
-declare const ace: any; //This is required for platfroms using ace code Editor
+declare const ace: any; //Ace Editor
 
 if (typeof browser !== 'undefined') {
     self.chrome = browser;
@@ -297,7 +297,7 @@ export const handleAtcoderSubmit = async (
                 setTimeout(async () => {
                     await chrome.scripting.executeScript({
                         target: { tabId, allFrames: false },
-                        files: ['/dist/AtcoderInjectedScript.js'],
+                        files: ['/dist/atcoderInjectedScript.js'],
                     });
 
                     chrome.tabs.sendMessage(tabId, {
@@ -323,14 +323,6 @@ export const handleAtcoderSubmit = async (
                             },
                             args: [sourceCode],
                         });
-
-                        setTimeout(() => {
-                            chrome.scripting.executeScript({
-                                target: { tabId, allFrames: false },
-                                func: () =>
-                                    document.getElementById('submit')?.click(),
-                            });
-                        }, 7000);
                     }, 1000);
                 }, 2000);
             }

--- a/src/handleSubmit.ts
+++ b/src/handleSubmit.ts
@@ -263,16 +263,6 @@ export const handleCodeChefSubmit = async (
                             },
                             args: [sourceCode],
                         });
-
-                        setTimeout(() => {
-                            chrome.scripting.executeScript({
-                                target: { tabId, allFrames: false },
-                                func: () =>
-                                    document
-                                        .getElementById('submit_btn')
-                                        ?.click(),
-                            });
-                        }, 500);
                     }, 1000);
                 }, 2000);
             }

--- a/src/handleSubmit.ts
+++ b/src/handleSubmit.ts
@@ -109,6 +109,14 @@ export const isCodeChefProblem = (problemUrl: string) => {
         return false;
     }
 };
+export const isAtcoderProblem = (problemUrl: string) => {
+    try {
+        const url = new URL(problemUrl);
+        return url.hostname.endsWith('atcoder.jp');
+    } catch {
+        return false;
+    }
+};
 
 export const handleAlgoZenithSubmit = async (
     problemName: string,
@@ -271,6 +279,64 @@ export const handleCodeChefSubmit = async (
         },
     );
 };
+export const handleAtcoderSubmit = async (
+    problemName: string,
+    languageId: number,
+    sourceCode: string,
+    problemUrl: string,
+) => {
+    const tab = await chrome.tabs.create({ active: true, url: problemUrl });
+    const tabId = tab.id as number;
+    chrome.windows.update(tab.windowId, { focused: true });
+
+    chrome.tabs.onUpdated.addListener(
+        function listener(updatedTabId, changeInfo) {
+            if (updatedTabId === tabId && changeInfo.status === 'complete') {
+                chrome.tabs.onUpdated.removeListener(listener);
+
+                setTimeout(async () => {
+                    await chrome.scripting.executeScript({
+                        target: { tabId, allFrames: false },
+                        files: ['/dist/AtcoderInjectedScript.js'],
+                    });
+
+                    chrome.tabs.sendMessage(tabId, {
+                        type: 'cph-submit-Atcoder',
+                        languageId,
+                    });
+
+                    /**ChromeV3 don't Allow us to inject script due to CSP policy**/
+                    setTimeout(async () => {
+                        await chrome.scripting.executeScript({
+                            target: { tabId, allFrames: false },
+                            world: 'MAIN',
+                            func: (code) => {
+                                const w = window as any;
+                                if (w.ace)
+                                    w.ace
+                                        .edit(
+                                            document.querySelector(
+                                                '.ace_editor',
+                                            ),
+                                        )
+                                        .setValue(code, -1);
+                            },
+                            args: [sourceCode],
+                        });
+
+                        setTimeout(() => {
+                            chrome.scripting.executeScript({
+                                target: { tabId, allFrames: false },
+                                func: () =>
+                                    document.getElementById('submit')?.click(),
+                            });
+                        }, 7000);
+                    }, 1000);
+                }, 2000);
+            }
+        },
+    );
+};
 export const handleSubmit = async (
     problemName: string,
     languageId: number,
@@ -300,6 +366,14 @@ export const handleSubmit = async (
     }
     if (isCodeChefProblem(problemUrl)) {
         return handleCodeChefSubmit(
+            problemName,
+            languageId,
+            sourceCode,
+            problemUrl,
+        );
+    }
+    if (isAtcoderProblem(problemUrl)) {
+        return handleAtcoderSubmit(
             problemName,
             languageId,
             sourceCode,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
         injectedScript: './src/injectedScript.ts',
         algoZenithInjectedScript: './src/algoZenithInjectedScript.ts',
         csesInjectedScript: './src/csesInjectedScript.ts',
+        codeChefInjectedScript: './src/codeChefInjectedScript.ts',
         offscreen: './src/offscreen.ts',
     },
     output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
         algoZenithInjectedScript: './src/algoZenithInjectedScript.ts',
         csesInjectedScript: './src/csesInjectedScript.ts',
         codeChefInjectedScript: './src/codeChefInjectedScript.ts',
+        atcoderInjectedScript: './src/atcoderInjectedScript.ts',
         offscreen: './src/offscreen.ts',
     },
     output: {


### PR DESCRIPTION
## feat: Add CodeChef & Atcoder Direct Submission Support

closes #41 
### Overview
This PR introduces direct problem submission support for CodeChef & Atcoder  in CPH, compatible with both Chrome (Manifest V3) and Firefox.

### Problem
CodeChef & Atcoder uses the Ace editor, which enforces a strict Content Security Policy (CSP) that prevents direct script injection via Chrome's Manifest V3. This required a non-standard approach to interact with the editor programmatically.

### Solution
for codehef:
To bypass the CSP restriction, source code is pushed directly into the page's main world memory rather than injected as a script. To bypass React's state isolation, we implemented a "human-simulation" approach . The script dispatches full native mouse event lifecycles (mouseover, mousedown, mouseup, click) to interact with the Material-UI dropdowns, forcing React to register the interactions and update its internal state accordingly.

for Atcoder:
we mapped the compiler ids to atcoder select options. Added cloudFareVerificationChecker() to constantly poll for verification for 4 times in every second, as soon as it finds the cloudfare token it auto submits the problem.

### Workflow
1. `handleSubmit.ts` detects a CodeChef or Atcoder problem and triggers `codechefInjectedScript.ts` or 'atcoderInjectedScript.ts'
2. The script selects the appropriate compiler language based on the user's setting
3.After a brief wait for the React portal to render, it locates the target language via data-value matching and simulates a click to select it.
4.The script waits for the UI animation to close and the internal React state to lock.
5.Source code is injected directly into the main world's ace editor instance.
6.final simulated click triggers the "Submit" button


### Changes
- Added `codechefInjectedScript.ts` — handles language selection and source code injection
- Added 'atcoderInjectedScript.ts'  — handles language selection and source code injection
- Updated `handleSubmit.ts` — added CodeChef , Atcoder submission handler
- Updated `manifest.json` — added required host permissions for CodeChef and Atcoder

### Notes
- Timeouts are intentional and necessary due to CodeChef's React render cycle
- Tested on both Chrome (MV3) and Firefox


CodeChef:
https://github.com/user-attachments/assets/5c797f9b-c523-4b14-a387-0a2ddbd98bfc

Atcoder:

https://github.com/user-attachments/assets/883c8014-94df-4150-8bd9-8015006f17dc







